### PR TITLE
Change guide on how to install all python dependencies in crypto and client libs

### DIFF
--- a/docs/sdk/python/client/intro.md
+++ b/docs/sdk/python/client/intro.md
@@ -44,21 +44,11 @@ cd python-client
 ```
 
 <!-- markdownlint-disable MD029 -->
-6. Once inside the virtualenv, you can proceed to install the dependencies. These are listed inside the setup.py file.
+6. Once inside the virtualenv, you can proceed to install dependencies.
 <!-- markdownlint-enable MD029 -->
 
 ```bash
-   pip install \
-      requests \
-      backoff \
-      flake8 \
-      flake8-import-order \
-      flake8-print \
-      flake8-quotes \
-      pytest \
-      pytest-responses \
-      pytest-mock \
-      pytest-cov
+python -m pip install -e ."[dev]"
 ```
 
 <!-- markdownlint-disable MD029 -->

--- a/docs/sdk/python/crypto/intro.md
+++ b/docs/sdk/python/crypto/intro.md
@@ -43,11 +43,11 @@ cd python-crypto
 ```
 
 <!-- markdownlint-disable MD029 -->
-6. Once inside the virtualenv, you can proceed to install the dependencies. These are listed inside the setup.py file.
+6. Once inside the virtualenv, you can proceed to install dependencies.
 <!-- markdownlint-enable MD029 -->
 
 ```bash
-pip install flake8 flake8-import-order flake8-print flake8-quotes pytest pytest-cov
+python -m pip install -e ."[dev]"
 ```
 
 <!-- markdownlint-disable MD029 -->


### PR DESCRIPTION
Current guide doesn't explain how to install all required dependencies and if user follows them still have many dependencies missing. I've replaced the command in the guide with one that installs all required libraries that are needed for development.