### PR TITLE
docs(sdk): update python-crypto api examples

### DIFF
--- a/docs/sdk/python/complementary-examples.md
+++ b/docs/sdk/python/complementary-examples.md
@@ -45,8 +45,8 @@ transaction = Transfer()
 
 transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
 transaction.set_nonce(nonce)
-transaction.add_payment(1, 'RECIPIENT_WALLET_ADDRESS_1')
-transaction.add_payment(2, 'RECIPIENT_WALLET_ADDRESS_2')
+transaction.add_transfer(1, 'RECIPIENT_WALLET_ADDRESS_1')
+transaction.add_transfer(2, 'RECIPIENT_WALLET_ADDRESS_2')
 #transaction.set_version(3)
 transaction.sign('this is a top secret passphrase')
 

--- a/docs/sdk/python/complementary-examples.md
+++ b/docs/sdk/python/complementary-examples.md
@@ -61,7 +61,7 @@ print(broadcastResponse)
 ```
 
 <x-alert type="info">
-The vendorField is optional and limited to a length of 255 characters. It can be a good idea to add a vendor field to your transactions if you want to be able to easily track them in the future.<br>
+The transaction memo (aka VendorField or SmartBridge) is optional and limited to a length of 255 characters. It can be a good idea to add a vendor field to your transactions if you want to be able to easily track them in the future.<br>
 Rest of the examples assume V3 transactions as default. You must set the version explicity using `transaction.set_version(int)` otherwise.
 </x-alert>
 
@@ -89,7 +89,7 @@ nonce = int(senderWallet['data']['nonce']) + 1
 transaction = LegacyTransfer(
     recipientId='RECIPIENT_WALLET_ADDRESS',
     amount=200000000,
-    vendorField="Hello World"
+    memo="Hello World"
 )
 transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
 transaction.set_nonce(nonce)

--- a/docs/sdk/python/complementary-examples.md
+++ b/docs/sdk/python/complementary-examples.md
@@ -41,13 +41,12 @@ senderWallet = client.wallets.get('SENDER_WALLET_ADDRESS')
 nonce = int(senderWallet['data']['nonce']) + 1
 
 # Step 2: Create the transaction
-transaction = Transfer(
-    recipientId='RECIPIENT_WALLET_ADDRESS',
-    amount=200000000,
-    vendorField="Hello World"
-)
+transaction = Transfer()
+
 transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
 transaction.set_nonce(nonce)
+transaction.add_payment(1, 'RECIPIENT_WALLET_ADDRESS_1')
+transaction.add_payment(2, 'RECIPIENT_WALLET_ADDRESS_2')
 #transaction.set_version(3)
 transaction.sign('this is a top secret passphrase')
 
@@ -65,6 +64,46 @@ print(broadcastResponse)
 The vendorField is optional and limited to a length of 255 characters. It can be a good idea to add a vendor field to your transactions if you want to be able to easily track them in the future.<br>
 Rest of the examples assume V3 transactions as default. You must set the version explicity using `transaction.set_version(int)` otherwise.
 </x-alert>
+
+## Creating and Broadcasting a Legacy Transfer
+
+```python
+from solar_client import SolarClient
+from solar_client.exceptions import SolarHTTPException
+from solar_crypto.constants import TRANSACTION_TYPE_GROUP
+from solar_crypto.configuration.network import set_network
+from solar_crypto.networks.testnet import Testnet
+from solar_crypto.transactions.builder.legacy_transfer import LegacyTransfer
+
+# Set your network
+set_network(Testnet)
+
+# Configure our API client
+client = SolarClient('https://sxp.testnet.sh/api')
+
+# Step 1: Retrieve the incremental nonce of the sender wallet
+senderWallet = client.wallets.get('SENDER_WALLET_ADDRESS')
+nonce = int(senderWallet['data']['nonce']) + 1
+
+# Step 2: Create the transaction
+transaction = LegacyTransfer(
+    recipientId='RECIPIENT_WALLET_ADDRESS',
+    amount=200000000,
+    vendorField="Hello World"
+)
+transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
+transaction.set_nonce(nonce)
+transaction.sign('this is a top secret passphrase')
+
+# Step 3: Broadcast the transaction
+try:
+    broadcastResponse = client.transactions.create([transaction.to_dict()])
+except SolarHTTPException as exception:
+    print(exception.response.json())
+
+# Step 4: Log the response
+print(broadcastResponse)
+```
 
 ## Creating and Broadcasting a Second Signature
 
@@ -139,6 +178,47 @@ except SolarHTTPException as exception:
 # Step 4: Log the response
 print(broadcastResponse)
 ```
+
+## Creating and Broadcasting a Delegate Resignation
+
+```python
+from solar_client import SolarClient
+from solar_client.exceptions import SolarHTTPException
+from solar_crypto.constants import TRANSACTION_TYPE_GROUP
+from solar_crypto.configuration.network import set_network
+from solar_crypto.networks.testnet import Testnet
+from solar_crypto.transactions.builder.delegate_resignation import DelegateResignation
+
+# Set your network
+set_network(Testnet)
+
+# Configure our API client
+client = SolarClient('https://sxp.testnet.sh/api')
+
+# Step 1: Retrieve the incremental nonce of the sender wallet
+senderWallet = client.wallets.get('SENDER_WALLET_ADDRESS')
+nonce = int(senderWallet['data']['nonce']) + 1
+
+# Step 2: Create the transaction
+transaction = DelegateResignation()
+
+transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
+transaction.set_nonce(nonce)
+transaction.sign('this is a top secret passphrase')
+
+# Step 3: Broadcast the transaction
+try:
+    broadcastResponse = client.transactions.create([transaction.to_dict()])
+except SolarHTTPException as exception:
+    print(exception.response.json())
+
+# Step 4: Log the response
+print(broadcastResponse)
+```
+
+<x-alert type="info">
+A delegate resignation has to be sent from the delegate wallet itself to verify its identity.
+</x-alert>
 
 ## Creating and Broadcasting a Vote (Solar Version >= 3.4.0)
 
@@ -302,86 +382,6 @@ except SolarHTTPException as exception:
 # Step 4: Log the response
 print(broadcastResponse)
 ```
-
-## Creating and Broadcasting a Multi Payment
-
-```python
-from solar_client import SolarClient
-from solar_client.exceptions import SolarHTTPException
-from solar_crypto.constants import TRANSACTION_TYPE_GROUP
-from solar_crypto.configuration.network import set_network
-from solar_crypto.networks.testnet import Testnet
-from solar_crypto.transactions.builder.multi_payment import MultiPayment
-
-# Set your network
-set_network(Testnet)
-
-# Configure our API client
-client = SolarClient('https://sxp.testnet.sh/api')
-
-# Step 1: Retrieve the incremental nonce of the sender wallet
-senderWallet = client.wallets.get('SENDER_WALLET_ADDRESS')
-nonce = int(senderWallet['data']['nonce']) + 1
-
-# Step 2: Create the transaction
-transaction = MultiPayment()
-
-transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
-transaction.set_nonce(nonce)
-transaction.add_payment(1, 'RECIPIENT_WALLET_ADDRESS_1')
-transaction.add_payment(2, 'RECIPIENT_WALLET_ADDRESS_2')
-transaction.sign('this is a top secret passphrase')
-
-# Step 3: Broadcast the transaction
-try:
-    broadcastResponse = client.transactions.create([transaction.to_dict()])
-except SolarHTTPException as exception:
-    print(exception.response.json())
-
-# Step 4: Log the response
-print(broadcastResponse)
-```
-
-## Creating and Broadcasting a Delegate Resignation
-
-```python
-from solar_client import SolarClient
-from solar_client.exceptions import SolarHTTPException
-from solar_crypto.constants import TRANSACTION_TYPE_GROUP
-from solar_crypto.configuration.network import set_network
-from solar_crypto.networks.testnet import Testnet
-from solar_crypto.transactions.builder.delegate_resignation import DelegateResignation
-
-# Set your network
-set_network(Testnet)
-
-# Configure our API client
-client = SolarClient('https://sxp.testnet.sh/api')
-
-# Step 1: Retrieve the incremental nonce of the sender wallet
-senderWallet = client.wallets.get('SENDER_WALLET_ADDRESS')
-nonce = int(senderWallet['data']['nonce']) + 1
-
-# Step 2: Create the transaction
-transaction = DelegateResignation()
-
-transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
-transaction.set_nonce(nonce)
-transaction.sign('this is a top secret passphrase')
-
-# Step 3: Broadcast the transaction
-try:
-    broadcastResponse = client.transactions.create([transaction.to_dict()])
-except SolarHTTPException as exception:
-    print(exception.response.json())
-
-# Step 4: Log the response
-print(broadcastResponse)
-```
-
-<x-alert type="info">
-A delegate resignation has to be sent from the delegate wallet itself to verify its identity.
-</x-alert>
 
 ## Creating and Broadcasting a HTLC Lock
 

--- a/docs/sdk/python/complementary-examples.md
+++ b/docs/sdk/python/complementary-examples.md
@@ -47,6 +47,7 @@ transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
 transaction.set_nonce(nonce)
 transaction.add_transfer(1, 'RECIPIENT_WALLET_ADDRESS_1')
 transaction.add_transfer(2, 'RECIPIENT_WALLET_ADDRESS_2')
+transaction.set_memo("Hello World")
 #transaction.set_version(3)
 transaction.sign('this is a top secret passphrase')
 
@@ -61,7 +62,7 @@ print(broadcastResponse)
 ```
 
 <x-alert type="info">
-The transaction memo (aka VendorField or SmartBridge) is optional and limited to a length of 255 characters. It can be a good idea to add a vendor field to your transactions if you want to be able to easily track them in the future.<br>
+The transaction memo is optional and limited to a length of 255 characters. It can be a good idea to add memo to your transactions if you want to be able to easily track them in the future.<br>
 Rest of the examples assume V3 transactions as default. You must set the version explicity using `transaction.set_version(int)` otherwise.
 </x-alert>
 
@@ -220,7 +221,7 @@ print(broadcastResponse)
 A delegate resignation has to be sent from the delegate wallet itself to verify its identity.
 </x-alert>
 
-## Creating and Broadcasting a Vote (Solar Version >= 3.4.0)
+## Creating and Broadcasting a Vote (Solar Version >= 4.0.0)
 
 ```python
 from solar_client import SolarClient
@@ -240,11 +241,11 @@ senderWallet = client.wallets.get('SENDER_WALLET_ADDRESS')
 nonce = int(senderWallet['data']['nonce']) + 1
 
 # Step 2: Create the transaction
-transaction = Vote(
+transaction = Vote()
 transaction.set_votes({"asterix": 34.9, "obelix": 35.1, "getafix": 30.0}) # must tot up to 100.00
 transaction.set_votes(["+asterix", "-obelix", "+getafix"]) # will ignore obelix and distribute the wallet to asterix & getafix 50:50
-transaction.set_votes(["-obelix"]) # will ignore obelix and unvote from all
-transaction.set_votes({}) #unvote
+transaction.set_votes(["-obelix"]) # will ignore obelix and cancel vote
+transaction.set_votes({}) #cancel vote
 transaction.set_nonce(nonce)
 transaction.sign('this is a top secret passphrase')
 
@@ -258,7 +259,7 @@ except SolarHTTPException as exception:
 print(broadcastResponse)
 ```
 
-## Creating and Broadcasting a Legacy Vote (Solar Version >= 3.3.0 & < 3.4.0)
+## Creating and Broadcasting a Legacy Vote (Solar Version >= 3.3.0 & < 4.0.0)
 
 ```python
 from solar_client import SolarClient
@@ -280,7 +281,7 @@ nonce = int(senderWallet['data']['nonce']) + 1
 
 # Step 2: Create the transaction
 transaction = LegacyVote()
-transaction.set_votes(["-obelix"])  # unvote
+transaction.set_votes(["-obelix"])  # cancel vote
 transaction.set_votes(["+asterix"]) # vote
 transaction.set_votes(["-obelix", "+asterix"]) # switch vote
 transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
@@ -297,7 +298,7 @@ except SolarHTTPException as exception:
 print(broadcastResponse)
 ```
 
-## Creating and Broadcasting a Multi Signature
+## Creating and Broadcasting a MultiSignature Registration
 
 ```python
 from solar_client import SolarClient
@@ -330,9 +331,6 @@ transaction.set_public_keys([
 transaction.add_participant(
     'participant_3_pk'
 )
-transaction.multi_sign('participant_1_passphrase', 0)
-transaction.multi_sign('participant_2_passphrase', 1)
-transaction.multi_sign('participant_3_passphrase', 2)
 
 transaction.sign('this is a top secret passphrase')
 

--- a/docs/sdk/python/crypto/api-documentation.md
+++ b/docs/sdk/python/crypto/api-documentation.md
@@ -773,7 +773,7 @@ Set the content identifier of the Transaction.
 
 `<class 'NoneType'>`
 
-## crypto.transactions.builder.multi_payment.MultiPayment
+## crypto.transactions.builder.transfer.Transfer
 
 ### `__init__()`
 
@@ -781,7 +781,7 @@ Set the content identifier of the Transaction.
 def __init__(self, vendorField=None, fee=None):
 ```
 
-Create a new MultiPayment transaction instance
+Create a new Transfer transaction instance
 
 #### Parameters
 
@@ -792,7 +792,7 @@ Create a new MultiPayment transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.multi_payment.MultiPayment'>`
+`<class 'crypto.transactions.builder.transfer.Transfer'>`
 
 ### `get_type_group()`
 
@@ -810,6 +810,25 @@ Get the type group of the Transaction.
 
 ```python
 def add_payment(self, amount, recipient_id):
+```
+
+Add a payment to the Payments array of a Transaction. Deprecated - use new add_transfer() method.
+
+#### Parameters
+
+| Type | Name | Required | Description |
+| :--- | :--- | :--- | :--- |
+| int | amount | Yes | Transaction amount |
+| string | recipient_id | Yes | Transaction recipient |
+
+#### Return Value
+
+`<class 'NoneType'>`
+
+### `add_transfer()`
+
+```python
+def add_transfer(self, amount, recipient_id):
 ```
 
 Add a payment to the Payments array of a Transaction.
@@ -920,7 +939,7 @@ Create a new SecondSignatureRegistration transaction instance
 
 `<class 'crypto.transactions.builder.second_signature_registration.SecondSignatureRegistration'>`
 
-## crypto.transactions.builder.Transfer.Transfer
+## crypto.transactions.builder.legacy_transfer.LegacyTransfer
 
 ### `__init__()`
 
@@ -928,7 +947,7 @@ Create a new SecondSignatureRegistration transaction instance
 def __init__(self, recipientId, amount, vendorField=None, fee=None):
 ```
 
-Create a new Transfer transaction instance
+Create a new Legacy Transfer transaction instance
 
 #### Parameters
 
@@ -941,9 +960,9 @@ Create a new Transfer transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.transfer.Transfer'>`
+`<class 'crypto.transactions.builder.legacy_transfer.LegacyTransfer'>`
 
-## crypto.transactions.builder.vote.Vote
+## crypto.transactions.builder.legacy_vote.LegacyVote
 
 ### `__init__()`
 
@@ -951,18 +970,18 @@ Create a new Transfer transaction instance
 def __init__(self, vote=None, fee=None):
 ```
 
-Create a new Vote transaction instance
+Create a new Legacy Vote transaction instance
 
 #### Parameters
 
 | Type | Name | Required | Description |
 | :--- | :--- | :--- | :--- |
-| str | vote | No | Vote |
+| str | vote | No | Delegate address to vote for |
 | int | fee | No | Transaction fee |
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.vote.Vote'>`
+`<class 'crypto.transactions.builder.legacy_vote.LegacyVote'>`
 
 ### `set_votes()`
 
@@ -970,7 +989,7 @@ Create a new Vote transaction instance
 def set_votes(self, votes: typing.List[str]):
 ```
 
-Set votes/unvotes
+Set legacy votes/unvotes
 
 #### Parameters
 
@@ -995,6 +1014,38 @@ Sign the transaction using the given passphrase
 | Type | Name | Required | Description |
 | :--- | :--- | :--- | :--- |
 | str | passphrase | Yes | Passphrase |
+
+#### Return Value
+
+`<class 'NoneType'>`
+
+## crypto.transactions.builder.vote.Vote
+
+### `__init__()`
+
+```python
+def __init__(self):
+```
+
+Create a new Vote transaction instance
+
+#### Return Value
+
+`<class 'crypto.transactions.builder.vote.Vote'>`
+
+### `set_votes()`
+
+```python
+def set_votes(self, votes: typing.Union[typing.List[str], typing.Dict[str, typing.Union[float, int]]] = dict):
+```
+
+Set votes
+
+#### Parameters
+
+| Type | Name | Required | Description |
+| :--- | :--- | :--- | :--- |
+| votes | votes | Yes | list of votes |
 
 #### Return Value
 
@@ -1132,7 +1183,7 @@ Handle the deserialization of "IPFS" data
 
 `<class 'dict'>`
 
-## crypto.transactions.deserializers.multi_payment.MultiPaymentDeserializer
+## crypto.transactions.deserializers.transfer.TransferDeserializer
 
 ### `deserialize()`
 
@@ -1140,7 +1191,7 @@ Handle the deserialization of "IPFS" data
 def deserialize(self):
 ```
 
-Handle the deserialization of "multi payments" data
+Handle the deserialization of "transfer" data
 
 #### Return Value
 
@@ -1174,7 +1225,7 @@ Handle the deserialization of "second signature" data.
 
 `<class 'dict'>`
 
-## crypto.transactions.deserializers.transfer.TransferDeserializer
+## crypto.transactions.deserializers.legacy_transfer.LegacyTransferDeserializer
 
 ### `deserialize()`
 
@@ -1182,7 +1233,21 @@ Handle the deserialization of "second signature" data.
 def deserialize(self):
 ```
 
-Handle the deserialization of "transfer" data
+Handle the deserialization of "legacy transfer" data
+
+#### Return Value
+
+`<class 'dict'>`
+
+## crypto.transactions.deserializers.legacy_vote.LegacyVoteDeserializer
+
+### `deserialize()`
+
+```python
+def deserialize(self):
+```
+
+Handle the deserialization of "legacy vote" data.
 
 #### Return Value
 
@@ -1333,7 +1398,7 @@ Handle the serialization of "ipfs" data
 
 `<class 'bytes'>`
 
-## crypto.transactions.serializers.multi_payment.MultiPaymentSerializer
+## crypto.transactions.serializers.transfer.TransferSerializer
 
 ### `serialize`
 
@@ -1341,7 +1406,7 @@ Handle the serialization of "ipfs" data
 def serialize(self):
 ```
 
-Handle the serialization of "multi payment" data
+Handle the serialization of "transfer" data
 
 #### Return Value
 
@@ -1375,7 +1440,7 @@ Handle the serialization of "second signature" data
 
 `<class 'bytes'>`
 
-## crypto.transactions.serializers.transfer.TransferSerializer
+## crypto.transactions.serializers.legacy_transfer.LegacyTransferSerializer
 
 ### `serialize`
 
@@ -1383,7 +1448,21 @@ Handle the serialization of "second signature" data
 def serialize(self):
 ```
 
-Handle the serialization of "transfer" data
+Handle the serialization of "legacy transfer" data
+
+#### Return Value
+
+`<class 'bytes'>`
+
+## crypto.transactions.serializers.legacy_vote.LegacyVoteSerializer
+
+### `serialize`
+
+```python
+def serialize(self):
+```
+
+Handle the serialization of "legacy vote" data
 
 #### Return Value
 

--- a/docs/sdk/python/crypto/api-documentation.md
+++ b/docs/sdk/python/crypto/api-documentation.md
@@ -656,7 +656,7 @@ Get the type group of the Transaction.
 ### `__init__()`
 
 ```python
-def __init__(self, recipient_id, amount, secret_hash, expiration_type, expiration_value, vendorField=None, fee=None):
+def __init__(self, recipient_id, amount, secret_hash, expiration_type, expiration_value, memo=None, fee=None):
 ```
 
 Create a new HtlcLock transaction instance
@@ -670,7 +670,7 @@ Create a new HtlcLock transaction instance
 | str | secret_hash | Yes | Transaction secret hash. The same hash must be used in the corresponding "claim" transaction |
 | int | expiration_type | Yes | Transaction expiration type. Either block height or network epoch timestamp based |
 | int | expiration_value | Yes | Transaction expiration value. The block-height or time when the transaction should expire |
-| str | vendorField | Yes | Transaction vendorfield |
+| str | memo | Yes | Transaction memo (aka VendorField or SmartBridge)|
 | int | fee | No | Transaction fee |
 
 #### Return Value
@@ -778,7 +778,7 @@ Set the content identifier of the Transaction.
 ### `__init__()`
 
 ```python
-def __init__(self, vendorField=None, fee=None):
+def __init__(self, memo=None, fee=None):
 ```
 
 Create a new Transfer transaction instance
@@ -787,7 +787,7 @@ Create a new Transfer transaction instance
 
 | Type | Name | Required | Description |
 | :--- | :--- | :--- | :--- |
-| str | vendorField | No | Transaction vendorfield |
+| str | memo | No | Transaction memo |
 | int | fee | No | Transaction fee |
 
 #### Return Value
@@ -944,7 +944,7 @@ Create a new SecondSignatureRegistration transaction instance
 ### `__init__()`
 
 ```python
-def __init__(self, recipientId, amount, vendorField=None, fee=None):
+def __init__(self, recipientId, amount, memo=None, fee=None):
 ```
 
 Create a new Legacy Transfer transaction instance
@@ -955,7 +955,7 @@ Create a new Legacy Transfer transaction instance
 | :--- | :--- | :--- | :--- |
 | str | recipientId | Yes | Recipient identifier |
 | int | amount | Yes | Transaction amount |
-| str | vendorField | No | Transaction vendorfield |
+| str | memo | No | Transaction memo |
 | int | fee | No | Transaction fee |
 
 #### Return Value

--- a/docs/sdk/python/crypto/api-documentation.md
+++ b/docs/sdk/python/crypto/api-documentation.md
@@ -703,7 +703,7 @@ Create a new HtlcLock transaction instance
 | str | secret_hash | Yes | Transaction secret hash. The same hash must be used in the corresponding "claim" transaction |
 | int | expiration_type | Yes | Transaction expiration type. Either block height or network epoch timestamp based |
 | int | expiration_value | Yes | Transaction expiration value. The block-height or time when the transaction should expire |
-| str | memo | Yes | Transaction memo (aka VendorField or SmartBridge)|
+| str | memo | Yes | Transaction memo|
 | int | fee | No | Transaction fee |
 
 #### Return Value
@@ -1003,7 +1003,7 @@ Create a new Legacy Vote transaction instance
 def set_votes(self, votes: typing.List[str]):
 ```
 
-Set legacy votes/unvotes
+Set legacy votes/cancel vote
 
 #### Parameters
 

--- a/docs/sdk/python/crypto/api-documentation.md
+++ b/docs/sdk/python/crypto/api-documentation.md
@@ -9,7 +9,7 @@ title: API Documentation
 ### `get_fee()`
 
 ```python
-def get_fee(transaction_type):
+def get_fee(transaction_type, type_group):
 ```
 
 Get a fee for a given transaction type
@@ -19,6 +19,7 @@ Get a fee for a given transaction type
 | Type | Name | Required | Description |
 | :--- | :--- | :--- | :--- |
 | int | transaction_type | Yes | Transaction type for which we wish to get a fee |
+| int | type_group | Yes | transaction type group (TRANSACTION_TYPE_GROUP(Enum)) |
 
 #### Return Value
 
@@ -27,7 +28,7 @@ Get a fee for a given transaction type
 ### `set_fee()`
 
 ```python
-def set_fee(transaction_type, value):
+def set_fee(transaction_type, type_group, value):
 ```
 
 Set a fee
@@ -37,6 +38,7 @@ Set a fee
 | Type | Name | Required | Description |
 | :--- | :--- | :--- | :--- |
 | int | transaction_type | Yes | Transaction type for which we wish to set a fee |
+| int | type_group | Yes | transaction type group (TRANSACTION_TYPE_GROUP(Enum)) |
 | int | value | Yes | Fee for a given transaction type |
 
 #### Return Value
@@ -57,7 +59,7 @@ Set what network you want to use in the crypto library
 
 | Type | Name | Required | Description |
 | :--- | :--- | :--- | :--- |
-| Network | network_object | Yes | Testnet, Testnet, Mainnet |
+| Network | network_object | Yes | Testnet, Mainnet |
 
 #### Return Value
 
@@ -69,7 +71,7 @@ Set what network you want to use in the crypto library
 def get_network():
 ```
 
-Get settings for a selected network, default network is testnet
+Get settings for a selected network, default network is Testnet
 
 #### Return Value
 
@@ -94,6 +96,18 @@ Set custom network
 #### Return Value
 
 `<class 'NoneType'>`
+
+### `get_network_version()`
+
+```python
+def get_network_version():
+```
+
+Get currently set network version
+
+#### Return Value
+
+`<class 'Network'>`
 
 ## crypto.identity.address
 
@@ -175,10 +189,28 @@ Validate a given address
 
 ## crypto.identity.private_key.PrivateKey
 
+### `__init__()`
+
+```python
+def __init__(self, private_key):
+```
+
+Create a new PrivateKey instance
+
+#### Parameters
+
+| Type | Name | Required | Description |
+| :--- | :--- | :--- | :--- |
+| str | private_key | Yes | Hex private key |
+
+#### Return Value
+
+`<class 'solar_crypto.identity.private_key.PrivateKey'>`
+
 ### `sign()`
 
 ```python
-def sign(self, message):
+def sign(self, message, nonce=None):
 ```
 
 Sign a message with this private key object
@@ -188,10 +220,11 @@ Sign a message with this private key object
 | Type | Name | Required | Description |
 | :--- | :--- | :--- | :--- |
 | str | message | Yes | Bytes data you want to sign |
+| int | nonce | No | Deterministic nonce |
 
 #### Return Value
 
-`<class 'NoneType'>`
+`<class 'str'>`
 
 ### `to_hex()`
 
@@ -226,7 +259,7 @@ Create PrivateKey object from a given passphrase
 ### `from_hex()`
 
 ```python
-def from_hex(self, private_key):
+def from_hex(cls, private_key):
 ```
 
 Create PrivateKey object from a given hex private key
@@ -543,7 +576,7 @@ Create a new Burn transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.burn.Burn'>`
+`<class 'solar_crypto.transactions.builder.burn.Burn'>`
 
 ## crypto.transactions.builder.delegate_registration.DelegateRegistration
 
@@ -564,7 +597,7 @@ Create a new DelegateRegistration transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.delegate_registration.DelegateRegistration'>`
+`<class 'solar_crypto.transactions.builder.delegate_registration.DelegateRegistration'>`
 
 ### `sign()`
 
@@ -602,7 +635,7 @@ Create a new DelegateResignation transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.delegate_resignation.DelegateResignation'>`
+`<class 'solar_crypto.transactions.builder.delegate_resignation.DelegateResignation'>`
 
 ### `get_type_group()`
 
@@ -637,7 +670,7 @@ Create a new HtlcClaim transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.htlc_claim.HtlcClaim'>`
+`<class 'solar_crypto.transactions.builder.htlc_claim.HtlcClaim'>`
 
 ### `get_type_group()`
 
@@ -675,7 +708,7 @@ Create a new HtlcLock transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.htlc_lock.HtlcLock'>`
+`<class 'solar_crypto.transactions.builder.htlc_lock.HtlcLock'>`
 
 ### `get_type_group()`
 
@@ -708,7 +741,7 @@ Create a new HtlcRefund transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.htlc_refund.HtlcRefund'>`
+`<class 'solar_crypto.transactions.builder.htlc_refund.HtlcRefund'>`
 
 ### `get_type_group()`
 
@@ -741,7 +774,7 @@ Create a new IPFS transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.ipfs.IPFS'>`
+`<class 'solar_crypto.transactions.builder.ipfs.IPFS'>`
 
 ### `get_type_group()`
 
@@ -792,7 +825,7 @@ Create a new Transfer transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.transfer.Transfer'>`
+`<class 'solar_crypto.transactions.builder.transfer.Transfer'>`
 
 ### `get_type_group()`
 
@@ -806,32 +839,13 @@ Get the type group of the Transaction.
 
 `<class 'int'>`
 
-### `add_payment()`
-
-```python
-def add_payment(self, amount, recipient_id):
-```
-
-Add a payment to the Payments array of a Transaction. Deprecated - use new add_transfer() method.
-
-#### Parameters
-
-| Type | Name | Required | Description |
-| :--- | :--- | :--- | :--- |
-| int | amount | Yes | Transaction amount |
-| string | recipient_id | Yes | Transaction recipient |
-
-#### Return Value
-
-`<class 'NoneType'>`
-
 ### `add_transfer()`
 
 ```python
 def add_transfer(self, amount, recipient_id):
 ```
 
-Add a payment to the Payments array of a Transaction.
+Add a transfer to the Transfers array of a Transaction.
 
 #### Parameters
 
@@ -862,7 +876,7 @@ Create a new MultiSignatureRegistration transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.multi_signature_registration.MultiSignatureRegistration'>`
+`<class 'solar_crypto.transactions.builder.multi_signature_registration.MultiSignatureRegistration'>`
 
 ### `set_min()`
 
@@ -937,7 +951,7 @@ Create a new SecondSignatureRegistration transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.second_signature_registration.SecondSignatureRegistration'>`
+`<class 'solar_crypto.transactions.builder.second_signature_registration.SecondSignatureRegistration'>`
 
 ## crypto.transactions.builder.legacy_transfer.LegacyTransfer
 
@@ -960,7 +974,7 @@ Create a new Legacy Transfer transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.legacy_transfer.LegacyTransfer'>`
+`<class 'solar_crypto.transactions.builder.legacy_transfer.LegacyTransfer'>`
 
 ## crypto.transactions.builder.legacy_vote.LegacyVote
 
@@ -981,7 +995,7 @@ Create a new Legacy Vote transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.legacy_vote.LegacyVote'>`
+`<class 'solar_crypto.transactions.builder.legacy_vote.LegacyVote'>`
 
 ### `set_votes()`
 
@@ -1031,12 +1045,12 @@ Create a new Vote transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.builder.vote.Vote'>`
+`<class 'solar_crypto.transactions.builder.vote.Vote'>`
 
 ### `set_votes()`
 
 ```python
-def set_votes(self, votes: typing.Union[typing.List[str], typing.Dict[str, typing.Union[float, int]]] = dict):
+def set_votes(self, votes: typing.Union[typing.List[str], typing.Dict[str, typing.Union[int, float, Decimal]]] = dict):
 ```
 
 Set votes
@@ -1071,7 +1085,7 @@ Create a new deserializer instance
 
 #### Return Value
 
-`<class 'crypto.transactions.deserializers.base.BaseDeserializer'>`
+`<class 'solar_crypto.transactions.deserializers.base.BaseDeserializer'>`
 
 ### `deserialize()`
 
@@ -1286,7 +1300,7 @@ Create a new serializer instance
 
 #### Return Value
 
-`<class 'crypto.transactions.serializers.base.BaseSerializer'>`
+`<class 'solar_crypto.transactions.serializers.base.BaseSerializer'>`
 
 ### `serialize`
 
@@ -1500,7 +1514,7 @@ Create a new deserializer instance
 
 #### Return Value
 
-`<class 'crypto.transactions.deserializer.Deserializer'>`
+`<class 'solar_crypto.transactions.deserializer.Deserializer'>`
 
 ### `deserialize`
 
@@ -1512,7 +1526,7 @@ Perform AIP11 compliant deserialization
 
 #### Return Value
 
-`<class 'crypto.transactions.transaction.Transaction'>`
+`<class 'solar_crypto.transactions.transaction.Transaction'>`
 
 ### `_handle_transaction_type`
 
@@ -1531,7 +1545,7 @@ Handle the deserialization of transaction data
 
 #### Return Value
 
-`<class 'crypto.transactions.transaction.Transaction'>`
+`<class 'solar_crypto.transactions.transaction.Transaction'>`
 
 ## crypto.transactions.serializer.Serializer
 
@@ -1551,7 +1565,7 @@ Create a new serializer instance
 
 #### Return Value
 
-`<class 'crypto.transactions.serializer.Serializer'>`
+`<class 'solar_crypto.transactions.serializer.Serializer'>`
 
 ### `serialize`
 
@@ -1632,7 +1646,7 @@ Create a new transaction instance
 
 #### Return Value
 
-`<class 'crypto.transactions.transaction.Transaction'>`
+`<class 'solar_crypto.transactions.transaction.Transaction'>`
 
 ### `get_id`
 
@@ -1939,7 +1953,7 @@ Create a new message instance
 
 #### Return Value
 
-`<class 'crypto.utils.message.Message'>`
+`<class 'solar_crypto.utils.message.Message'>`
 
 ### `sign`
 
@@ -1958,7 +1972,7 @@ Sign a message using the given passphrase
 
 #### Return Value
 
-`<class 'crypto.utils.message.Message'>`
+`<class 'solar_crypto.utils.message.Message'>`
 
 ### `verify`
 

--- a/docs/sdk/python/crypto/examples.md
+++ b/docs/sdk/python/crypto/examples.md
@@ -7,26 +7,34 @@ title: Examples
 ## Initialization
 
 ```python
-from crypto.transactions.builder.transfer import Transfer
+from solar_crypto.transactions.builder.transfer import Transfer
 ```
 
 The transaction object used for this section:
 
 ```python
 tx = {
-    'version': int,
-    'network': int,
-    'type': int,
-    'timestamp': int,
-    'senderPublicKey', str
-    'fee': int,
     'amount': int,
-    'expiration': int,
+    'asset': dict,
+    'fee': int,
+    'id': str,
+    'network': int,
     'recipientId': str,
+    'secondSignature': str,
+    'senderPublicKey': str,
     'signature': str,
-    'id': str
-    'serialized': str,
+    'signatures': list,
+    'signSignature': str,
+    'nonce': int,
+    'type': int,
+    'typeGroup': int,
+    'vendorField': str,
+    'version': int,
+    'lockTransactionId': str,
+    'lockSecret': str,
+    'expiration': int,
 }
+
 ```
 
 ## Transactions
@@ -40,7 +48,7 @@ The crypto SDK can sign a transaction using your private key or passphrase (from
 For serializing and deserializing, we must require the Transaction model:
 
 ```python
-from crypto.transactions.transaction import Transaction
+from solar_crypto.transactions.transaction import Transaction
 
 # Serializing
 transaction = Transaction(**tx)
@@ -55,7 +63,7 @@ Using the Transaction builder class.
 
 ```python
 transaction = Transfer(recipientId=str, amount=int)
-transaction.schnorr_sign('seedPass')
+transaction.sign('seedPass')
 ```
 
 ### Serialize (AIP11)
@@ -63,7 +71,7 @@ transaction.schnorr_sign('seedPass')
 > Serialization of a transaction object ensures it is compact and properly formatted to be incorporated in the SXP blockchain. If you are using the crypto SDK in combination with the public API SDK, you should not need to serialize manually.
 
 ```python
-from crypto.transactions.serializer import Serializer
+from solar_crypto.transactions.serializer import Serializer
 
 serialized_transaction = Serializer(tx).serialize()
 
@@ -75,7 +83,7 @@ serialized_transaction = Serializer(tx).serialize()
 > A serialized transaction may be deserialized for inspection purposes. The public API does not return serialized transactions, so you should only need to deserialize in exceptional circumstances.
 
 ```python
-from crypto.transactions.deserializer import Deserializer
+from solar_crypto.transactions.deserializer import Deserializer
 
 transaction_data = Deserializer(serialized_data).deserialize()
 
@@ -91,7 +99,7 @@ The crypto SDK not only supports transactions but can also work with other arbit
 > Signing a string works much like signing a transaction: in most implementations, the message is hashed, and the resulting hash is signed using the `private key` or `passphrase`.
 
 ```python
-from crypto.utils.message import Message
+from solar_crypto.utils.message import Message
 
 message = Message.sign(string, 'validSeedPass')
 
@@ -103,16 +111,13 @@ message = Message.sign(string, 'validSeedPass')
 > A message's signature can easily be verified by hash, without the private key that signed the message, by using the `verify` method.
 
 ```python
-from crypto.utils.message import Message
+from solar_crypto.utils.message import Message
 
 message = Message(
     message=str,
     signature=str,
-    public_key=str
+    publicKey=str
 )
-
-# Can also be used like this
-message = Message(str, 'validSignature', 'validPublicKey')
 
 message.verify()
 
@@ -126,7 +131,7 @@ message.verify()
 ### Derive the Address from a Passphrase
 
 ```python
-from crypto.identity.address import address_from_passphrase
+from solar_crypto.identity.address import address_from_passphrase
 
 address_from_passphrase('validSeedPass')
 
@@ -136,7 +141,7 @@ address_from_passphrase('validSeedPass')
 ### Derive the Address from a Public Key
 
 ```python
-from crypto.identity.address import address_from_public_key
+from solar_crypto.identity.address import address_from_public_key
 
 address_from_public_key('validPublicKey')
 
@@ -146,7 +151,7 @@ address_from_public_key('validPublicKey')
 ### Derive the Address from a Private Key
 
 ```python
-from crypto.identity.address import address_from_private_key
+from solar_crypto.identity.address import address_from_private_key
 
 address_from_private_key('validPrivateKey')
 
@@ -156,7 +161,7 @@ address_from_private_key('validPrivateKey')
 ### Validate an Address
 
 ```python
-from crypto.identity.address import validate_address
+from solar_crypto.identity.address import validate_address
 
 validate_address('validAddress')
 
@@ -170,7 +175,7 @@ validate_address('validAddress')
 ### Derive the Private Key from a Passphrase
 
 ```python
-from crypto.identity.private_key import PrivateKey
+from solar_crypto.identity.private_key import PrivateKey
 
 private_key = PrivateKey.from_passphrase('validSeedPass').to_hex()
 
@@ -180,7 +185,7 @@ private_key = PrivateKey.from_passphrase('validSeedPass').to_hex()
 ### Derive the Private Key Instance Object from a Hexadecimal Encoded String
 
 ```python
-from crypto.identity.private_key import PrivateKey
+from solar_crypto.identity.private_key import PrivateKey
 
 private_key = PrivateKey.from_hex(str)
 
@@ -200,7 +205,7 @@ This function has not been implemented in this client library.
 ### Derive the Public Key from a Passphrase
 
 ```python
-from crypto.identity.public_key import PublicKey
+from solar_crypto.identity.public_key import PublicKey
 
 public_key = PublicKey.from_passphrase('this is a top secret passphrase')
 
@@ -210,7 +215,7 @@ public_key = PublicKey.from_passphrase('this is a top secret passphrase')
 ### Derive the Public Key Instance Object from a Hexadecimal Encoded String
 
 ```python
-from crypto.identity.public_key import PublicKey
+from solar_crypto.identity.public_key import PublicKey
 
 public_key = PublicKey.from_hex(str)
 
@@ -230,7 +235,7 @@ This function has not been implemented in this client library.
 ### Derive the WIF from a Passphrase
 
 ```python
-from crypto.identity.wif import wif_from_passphrase
+from solar_crypto.identity.wif import wif_from_passphrase
 
 wif = wif_from_passphrase('validSeedPass')
 

--- a/docs/sdk/python/crypto/examples.md
+++ b/docs/sdk/python/crypto/examples.md
@@ -28,7 +28,7 @@ tx = {
     'nonce': int,
     'type': int,
     'typeGroup': int,
-    'vendorField': str,
+    'memo': str,
     'version': int,
     'lockTransactionId': str,
     'lockSecret': str,

--- a/docs/sdk/python/crypto/examples.md
+++ b/docs/sdk/python/crypto/examples.md
@@ -87,7 +87,7 @@ from solar_crypto.transactions.deserializer import Deserializer
 
 transaction_data = Deserializer(serialized_data).deserialize()
 
->>> <class 'crypto.transactions.transaction.Transaction'>
+>>> <class 'solar_crypto.transactions.transaction.Transaction'>
 ```
 
 ## Message
@@ -103,7 +103,7 @@ from solar_crypto.utils.message import Message
 
 message = Message.sign(string, 'validSeedPass')
 
->>> <class 'crypto.utils.message.Message'>
+>>> <class 'solar_crypto.utils.message.Message'>
 ```
 
 ### Verify
@@ -189,7 +189,7 @@ from solar_crypto.identity.private_key import PrivateKey
 
 private_key = PrivateKey.from_hex(str)
 
->>> <class 'crypto.identity.private_key.PrivateKey'>
+>>> <class 'solar_crypto.identity.private_key.PrivateKey'>
 ```
 
 ### Derive the Private Key from a WIF
@@ -219,7 +219,7 @@ from solar_crypto.identity.public_key import PublicKey
 
 public_key = PublicKey.from_hex(str)
 
->>> <class 'crypto.identity.public_key.PublicKey'>
+>>> <class 'solar_crypto.identity.public_key.PublicKey'>
 ```
 
 ### Validate a Public Key


### PR DESCRIPTION
Examples updated to work with solar-crypto and solar-client api v3.0.0, cross-checking against the libraries and adding code fragments from @c0nsol3 library/tests as necessary. Removed obsolete info and instructions.

needs to be merged after solar-client PR#7 and solar-crypto PR#32.

