### PR TITLE
build: remove instant navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,6 @@ theme:
     - header.autohide
     - navigation.expand
     - navigation.indexes
-    - navigation.instant
     - navigation.sections
     - navigation.tabs
     - navigation.tabs.sticky


### PR DESCRIPTION
The instant loading (`navigation.instant`) MkDocs Material feature interferes with the rendering of several doc pages.

For instance, the API swagger page requires a manual reload when this feature is enabled.

This PR proposes the removal of the `navigation.instant` feature from the `mkdocs.yml` configuration file.

*(The details of this feature can be found here: [https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=nav#instant-loading](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=nav#instant-loading))*