### PR TITLE
chore: remove explorer links

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -9,9 +9,6 @@ This section serves as a reference for the available Solar Core APIs. These APIs
 1. [Public REST API](/api/public-rest-api/getting-started)
 2. [Webhook API](/api/webhook-api/getting-started)
 
-!!! info
+!!! tip "The API can also help monitor and troubleshoot your own node"
 
-    Each Core instance has its own internal blockchain and state, meaning it may have forked or be out of sync, causing queries to fail. Monitor your node by comparing it to different public nodes, such as the official Mainnet or Testnet Explorer to ensure you are in sync.
-
-    - **Mainnet Block Explorer** - <a href="https://solarscan.com" target="_blank" rel="noopener noreferrer">solarscan.com</a>
-    - **Testnet Block Explorer** - <a href="https://testnet.solarscan.com" target="_blank" rel="noopener noreferrer">testnet.solarscan.com</a>
+    Since each Core instance operates with its own internal blockchain and state, it's possible for it to become out of sync or forked, which may result in query failures. This makes the Solar Core APIs a valuable resource for managing your node and troubleshooting issues by comparing its responses with those of other nodes.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,5 +13,5 @@ This section serves as a reference for the available Solar Core APIs. These APIs
 
     Each Core instance has its own internal blockchain and state, meaning it may have forked or be out of sync, causing queries to fail. Monitor your node by comparing it to different public nodes, such as the official Mainnet or Testnet Explorer to ensure you are in sync.
 
-    - **Mainnet Explorer** - <a href="https://explorer.solar.org" target="_blank" rel="noopener noreferrer">explorer.solar.org</a>
-    - **Testnet Explorer** - <a href="https://texplorer.solar.org" target="_blank" rel="noopener noreferrer">texplorer.solar.org</a>
+    - **Mainnet Block Explorer** - <a href="https://solarscan.com" target="_blank" rel="noopener noreferrer">solarscan.com</a>
+    - **Testnet Block Explorer** - <a href="https://testnet.solarscan.com" target="_blank" rel="noopener noreferrer">testnet.solarscan.com</a>

--- a/docs/api/public-rest-api/getting-started.md
+++ b/docs/api/public-rest-api/getting-started.md
@@ -14,8 +14,8 @@ This is the reference guide for the Public API. This API exposes all resources a
 
     Each Core instance has its own internal blockchain and state, meaning it may have forked or be out of sync, causing queries to fail. Monitor your node by comparing it to different public nodes, such as the official Mainnet or Testnet Explorer to ensure you are in sync.
 
-    - **Mainnet Explorer** - <a href="https://explorer.solar.org" target="_blank" rel="noopener noreferrer">explorer.solar.org</a>
-    - **Testnet Explorer** - <a href="https://texplorer.solar.org" target="_blank" rel="noopener noreferrer">texplorer.solar.org</a>
+    - **Mainnet Block Explorer** - <a href="https://solarscan.com" target="_blank" rel="noopener noreferrer">solarscan.com</a>
+    - **Testnet Block Explorer** - <a href="https://testnet.solarscan.com" target="_blank" rel="noopener noreferrer">testnet.solarscan.com</a>
 
 !!! question "If you have any problems or requests, please <a href="https://github.com/solar-network/core/issues/new/choose" target="_blank" rel="noopener noreferrer">open an issue</a>."
 

--- a/docs/api/public-rest-api/getting-started.md
+++ b/docs/api/public-rest-api/getting-started.md
@@ -10,13 +10,6 @@ title: Getting Started
 
 This is the reference guide for the Public API. This API exposes all resources and data provided by a Solar Core node and is the preferred way of interacting with the Solar Network.
 
-!!! info
-
-    Each Core instance has its own internal blockchain and state, meaning it may have forked or be out of sync, causing queries to fail. Monitor your node by comparing it to different public nodes, such as the official Mainnet or Testnet Explorer to ensure you are in sync.
-
-    - **Mainnet Block Explorer** - <a href="https://solarscan.com" target="_blank" rel="noopener noreferrer">solarscan.com</a>
-    - **Testnet Block Explorer** - <a href="https://testnet.solarscan.com" target="_blank" rel="noopener noreferrer">testnet.solarscan.com</a>
-
 !!! question "If you have any problems or requests, please <a href="https://github.com/solar-network/core/issues/new/choose" target="_blank" rel="noopener noreferrer">open an issue</a>."
 
 ## Pagination

--- a/docs/desktop-wallet/rewards.md
+++ b/docs/desktop-wallet/rewards.md
@@ -56,7 +56,7 @@ As previously stated, block rewards and transaction fees are awarded to the acti
 
 Reward sharing can vary wildly with delegates taking commissions of anywhere from 0-100% of the total rewards.
 
-You can also view current Solar delegates on the [Delegates](https://explorer.solar.org/delegates) page inside the [SXP Explorer](https://explorer.solar.org/).
+You can also view all registered block producers using Solarscan: <a href="https://solarscan.com/block-producers" target="_blank" rel="noopener noreferrer">solarscan.com/block-producers</a>
 
 <!-- --hidden-- needs more detailed information
 ## Becoming a Delegate

--- a/docs/desktop-wallet/rewards.md
+++ b/docs/desktop-wallet/rewards.md
@@ -56,7 +56,7 @@ As previously stated, block rewards and transaction fees are awarded to the acti
 
 Reward sharing can vary wildly with delegates taking commissions of anywhere from 0-100% of the total rewards.
 
-You can also view all registered block producers using Solarscan: <a href="https://solarscan.com/block-producers" target="_blank" rel="noopener noreferrer">solarscan.com/block-producers</a>
+!!! tip "You can also view all registered block producers using the public [REST API](/api/public-rest-api/getting-started) or a block explorer"
 
 <!-- --hidden-- needs more detailed information
 ## Becoming a Delegate

--- a/docs/desktop-wallet/support/troubleshooting.md
+++ b/docs/desktop-wallet/support/troubleshooting.md
@@ -73,7 +73,7 @@ This restarts all services related to the SXP Desktop Wallet, no data will be lo
 
 !!! success
 
-    Tip: Enter your SXP Address at [explorer.solar.org](http://explorer.solar.org) to verify balances and transactions.
+    Tip: Enter your SXP address on <a href="https://solarscan.com" target="_blank" rel="noopener noreferrer">solarscan.com</a> to verify balances and transactions.
 
 ## Wallet Issues
 
@@ -109,7 +109,7 @@ If the mnemonic passphrase was entered **exactly** as recorded, compare each wor
 
 !!! success
 
-    Tip: Enter your SXP Address at [explorer.solar.org](http://explorer.solar.org) to check that the balance and transaction history are as expected.
+    Tip: Enter your SXP address on <a href="https://solarscan.com" target="_blank" rel="noopener noreferrer">solarscan.com</a> to verify balances and transactions.
 
 ---
 

--- a/docs/desktop-wallet/support/troubleshooting.md
+++ b/docs/desktop-wallet/support/troubleshooting.md
@@ -71,10 +71,6 @@ This restarts all services related to the SXP Desktop Wallet, no data will be lo
 
     If the **connection issues** are **not** resolved using the advice above, check that your connections are not being blocked by **Firewall** or **Antivirus Software**.
 
-!!! success
-
-    Tip: Enter your SXP address on <a href="https://solarscan.com" target="_blank" rel="noopener noreferrer">solarscan.com</a> to verify balances and transactions.
-
 ## Wallet Issues
 
 <u>**Wallet**</u> issues are encountered while attempting to <u>**import**</u>/<u>**restore**</u> a wallet using a **mnemonic recovery passphrase**.
@@ -106,10 +102,6 @@ If the mnemonic passphrase was entered **exactly** as recorded, compare each wor
 !!! info
 
     The purpose of checking this wordlist is to ensure that similar words were not recorded inadvertently.<br>*e.g. "aim" vs "air"; "fine" vs "find"; "seek" vs "seed"*
-
-!!! success
-
-    Tip: Enter your SXP address on <a href="https://solarscan.com" target="_blank" rel="noopener noreferrer">solarscan.com</a> to verify balances and transactions.
 
 ---
 

--- a/docs/desktop-wallet/user-guides/vote.md
+++ b/docs/desktop-wallet/user-guides/vote.md
@@ -28,7 +28,7 @@ Each transaction in the SXP network costs a certain amount of SXP. With the impl
 
 Visit [SXP Delegates](https://delegates.solar.org/), our community-run delegate resource, for more information on delegate proposals. From the current list of delegates, vote according to your preferences.
 
-You can also see the list of currently active delegates on our [delegate monitor](https://explorer.solar.org/delegates).
+You can also view all registered block producers using Solarscan: <a href="https://solarscan.com/block-producers" target="_blank" rel="noopener noreferrer">solarscan.com/block-producers</a>
 
 ## Voting for a delegate
 

--- a/docs/desktop-wallet/user-guides/vote.md
+++ b/docs/desktop-wallet/user-guides/vote.md
@@ -28,7 +28,7 @@ Each transaction in the SXP network costs a certain amount of SXP. With the impl
 
 Visit [SXP Delegates](https://delegates.solar.org/), our community-run delegate resource, for more information on delegate proposals. From the current list of delegates, vote according to your preferences.
 
-You can also view all registered block producers using Solarscan: <a href="https://solarscan.com/block-producers" target="_blank" rel="noopener noreferrer">solarscan.com/block-producers</a>
+!!! tip "You can also view all registered block producers using the public [REST API](/api/public-rest-api/getting-started) or a block explorer"
 
 ## Voting for a delegate
 


### PR DESCRIPTION
There is no longer an official Solar Network block explorer.

This PR removes the relevant links and references throughout the documentation.