### PR TITLE
docs(core): update transfer admonitions

### DIFF
--- a/docs/core/transactions/types/legacy-transfer.md
+++ b/docs/core/transactions/types/legacy-transfer.md
@@ -6,7 +6,7 @@ title: Transfer (Legacy)
 
 !!! danger "<u>Type 0</u> Transfers are deprecated"
 
-    - <u>Type 0</u> Transfers will not be accepted by the Solar blockchain soon* ❌
+    - <u>Type 0</u> Transfers will not be accepted by the Solar blockchain starting at height 5,000,000* ❌
     - <u>Type 6</u> Transfers should be used from now on ✅
 
     &emsp;&nbsp;<i>*exchanges should continue to detect and accept legacy (type 0) transfers for the time being</i>

--- a/docs/core/transactions/types/legacy-transfer.md
+++ b/docs/core/transactions/types/legacy-transfer.md
@@ -6,7 +6,7 @@ title: Transfer (Legacy)
 
 !!! danger "<u>Type 0</u> Transfers are deprecated"
 
-    - <u>Type 0</u> Transfers will not be accepted by the Solar blockchain starting at height 5,000,000* ❌
+    - <u>Type 0</u> Transfers will not be accepted on the Solar Network mainnet starting at height 5,000,000* ❌
     - <u>Type 6</u> Transfers should be used from now on ✅
 
     &emsp;&nbsp;<i>*exchanges should continue to detect and accept legacy (type 0) transfers for the time being</i>

--- a/docs/core/transactions/types/legacy-transfer.md
+++ b/docs/core/transactions/types/legacy-transfer.md
@@ -4,10 +4,12 @@ title: Transfer (Legacy)
 
 # Legacy Transfer _(**DEPRECATED**)_
 
-!!! danger "<u>Type 0</u> Transfers will be deprecated on 31st December 2022"
+!!! danger "<u>Type 0</u> Transfers are deprecated"
 
-    - <u>Type 0</u> Transfers will <u>**NOT**</u> be accepted by the Solar blockchain after 2022-12-31 ❌
+    - <u>Type 0</u> Transfers will not be accepted by the Solar blockchain soon* ❌
     - <u>Type 6</u> Transfers should be used from now on ✅
+
+    &emsp;&nbsp;<i>*exchanges should continue to detect and accept legacy (type 0) transfers for the time being</i>
 
 !!! tip "See the updated transaction type here: [Transfer (Type 6)](/core/transactions/types/transfer)"
 

--- a/docs/core/transactions/types/transfer.md
+++ b/docs/core/transactions/types/transfer.md
@@ -8,7 +8,7 @@ title: Transfer
 
 !!! info "<u>Type 0</u> Transfers are deprecated"
 
-    - <u>Type 0</u> Transfers will not be accepted by the Solar blockchain starting at height 5,000,000* ❌
+    - <u>Type 0</u> Transfers will not be accepted on the Solar Network mainnet starting at height 5,000,000* ❌
     - <u>Type 6</u> Transfers should be used from now on ✅
 
     &emsp;&nbsp;<i>*exchanges should continue to detect and accept legacy (type 0) transfers for the time being</i>

--- a/docs/core/transactions/types/transfer.md
+++ b/docs/core/transactions/types/transfer.md
@@ -8,7 +8,7 @@ title: Transfer
 
 !!! info "<u>Type 0</u> Transfers are deprecated"
 
-    - <u>Type 0</u> Transfers will not be accepted by the Solar blockchain soon* ❌
+    - <u>Type 0</u> Transfers will not be accepted by the Solar blockchain starting at height 5,000,000* ❌
     - <u>Type 6</u> Transfers should be used from now on ✅
 
     &emsp;&nbsp;<i>*exchanges should continue to detect and accept legacy (type 0) transfers for the time being</i>

--- a/docs/core/transactions/types/transfer.md
+++ b/docs/core/transactions/types/transfer.md
@@ -6,10 +6,12 @@ title: Transfer
 
 !!! success "This page contains the latest <u>Type 6</u> Transfer"
 
-!!! danger "<u>Type 0</u> Transfers will be deprecated on 31st December 2022"
+!!! info "<u>Type 0</u> Transfers are deprecated"
 
-    - <u>Type 0</u> Transfers will <u>**NOT**</u> be accepted by the Solar blockchain after 2022-12-31 ❌
+    - <u>Type 0</u> Transfers will not be accepted by the Solar blockchain soon* ❌
     - <u>Type 6</u> Transfers should be used from now on ✅
+
+    &emsp;&nbsp;<i>*exchanges should continue to detect and accept legacy (type 0) transfers for the time being</i>
 
 | TypeGroup | Type  |
 | :-------: | :---: |


### PR DESCRIPTION
This PR proposes permanently committing a previously deployed phrasing update for legacy transfer admonitions/callouts into the repository.