### PR TITLE
docs(core): fix typescript sdk link

### DIFF
--- a/docs/core/transactions/types/transfer.md
+++ b/docs/core/transactions/types/transfer.md
@@ -129,7 +129,7 @@ The steps needed to utilise the new Type 6 Transfer will depend heavily on what 
     See the full SDK examples of sending a Type 6 Transfer at the following links:
 
     - Python: [Creating and broadcasting a transfer transaction](/sdk/python/complementary-examples/#creating-and-broadcasting-a-transfer-transaction)
-    - TypeScript: [Creating and broadcasting a transfer transaction](/sdk/python/complementary-examples/#creating-and-broadcasting-a-transfer-transaction)
+    - TypeScript: [Creating and broadcasting a transfer transaction](/sdk/typescript/complementary-examples/#creating-and-broadcasting-a-transfer-transaction)
 
 !!! warning "Make sure you are also using the latest SDK releases"
 


### PR DESCRIPTION
This PR proposes permanently committing a previously deployed correction of a TypeScript SDK link into the repository.