### PR TITLE
docs(core): update prior release transfer admonitions

### DIFF
--- a/docs/core/updates/4.2.0.md
+++ b/docs/core/updates/4.2.0.md
@@ -15,10 +15,12 @@ title: 4.2.0
 
 ---
 
-!!! warning "<u>Type 0</u> Transfers will soon be deprecated"
+!!! warning "<u>Type 0</u> Transfers are deprecated"
 
-    - <u>Type 0</u> Transfers will <u>**NOT**</u> be accepted by the Solar blockchain after being deprecated ❌
+    - <u>Type 0</u> Transfers will not be accepted on the Solar Network mainnet starting at height 5,000,000* ❌
     - <u>Type 6</u> Transfers should be used from now on ✅
+
+    &emsp;&nbsp;<i>*exchanges should continue to detect and accept legacy (type 0) transfers for the time being</i>
 
 !!! tip "See the updated transaction type here: [Transfer (Type 6)](/core/transactions/types/transfer)"
 

--- a/docs/core/updates/4.2.1.md
+++ b/docs/core/updates/4.2.1.md
@@ -6,10 +6,12 @@ title: 4.2.1
 
 ---
 
-!!! warning "<u>Type 0</u> Transfers will soon be deprecated"
+!!! warning "<u>Type 0</u> Transfers are deprecated"
 
-    - <u>Type 0</u> Transfers will <u>**NOT**</u> be accepted by the Solar blockchain after being deprecated ❌
+    - <u>Type 0</u> Transfers will not be accepted on the Solar Network mainnet starting at height 5,000,000* ❌
     - <u>Type 6</u> Transfers should be used from now on ✅
+
+    &emsp;&nbsp;<i>*exchanges should continue to detect and accept legacy (type 0) transfers for the time being</i>
 
 !!! tip "See the updated transaction type here: [Transfer (Type 6)](/core/transactions/types/transfer)"
 


### PR DESCRIPTION
The block at which legacy type 0 transfers will no longer be accepted on the Solar Network mainnet has been set (height 5,000,000) and updated phrasing has been proposed for other relevant sections in PRs https://github.com/Solar-network/docs/pull/24 and https://github.com/Solar-network/docs/pull/26.

This PR proposes updating the legacy transfer deprecation warnings found on prior Core release pages (`4.2.1` and `4.2.0`) to match this new phrasing.