### PR TITLE
chore: add build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 # Build files
 /build
 /MANIFEST
+/site
 
 # Distribution files
 /dist


### PR DESCRIPTION
This PR proposes updating the doc repo's `.gitignore` to exclude files generated during the build process, which will help prevent these auto-generated files from being unintentionally committed.